### PR TITLE
Fix allow_list.json path in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ Create your `allow_list.json` file in the root of this repo. It should look some
 Run the following command which builds and deploys your server listening on the default port `8080`. The `allow_list.json` is passed in as a volume at runtime.
 
 ```bash
-docker build -t earthstar-replica-server . && docker run -v $(pwd)/allow_list.json:/app/replica-server/allow_list.json -it --init -p 8080:8080 earthstar-replica-server
+docker build -t earthstar-replica-server . && docker run -v $(pwd)/allow_list.json:/app/allow_list.json -it --init -p 8080:8080 earthstar-replica-server
 ```


### PR DESCRIPTION
With replica server 1.1.0 running the image fails with:

```
error: Uncaught (in promise) NotFound: No such file or directory (os error 2), open '/app/allow_list.json'
```